### PR TITLE
Fix duration addition issue

### DIFF
--- a/hbsir/data_engine.py
+++ b/hbsir/data_engine.py
@@ -148,6 +148,9 @@ class SchemaApplier:
             self._apply_categorical_instruction(column_name, instruction)
 
     def _apply_numerical_instruction(self, column_name, instruction: dict) -> None:
+        if isinstance(instruction["expression"], int):
+            self.table[column_name] = instruction["expression"]
+            return
         columns_names = re.split(r"[\+\-\*\/\s\.]+", instruction["expression"])
         columns_names = [name for name in columns_names if not name.isnumeric()]
         self.table[column_name] = (

--- a/hbsir/metadata/schema.yaml
+++ b/hbsir/metadata/schema.yaml
@@ -29,7 +29,6 @@ common_order: &common_order
 _expenditure_tables_settings: &expenditure_tables_settings
   add_table_names: true
   add_year: true
-  add_duration: false
 
 food:
   settings: *expenditure_tables_settings
@@ -59,76 +58,156 @@ food:
         type: numerical
         expression: "0.001 * Grams + Kilos"
 
+    Duration:
+      type: numerical
+      expression: 30
+
 
 tobacco:
   settings: *expenditure_tables_settings
+
+  columns:
+    Duration:
+      type: numerical
+      expression: 30
+
   order: *common_order
 
 
 cloth:
   settings: *expenditure_tables_settings
+
+  columns:
+    Duration:
+      type: numerical
+      expression: 30
+
   order: *common_order
 
 
 home:
   settings: *expenditure_tables_settings
+
+  columns:
+    Duration:
+      type: numerical
+      expression: 30
+
   order: *common_order
 
 
 furniture:
   settings: *expenditure_tables_settings
+
+  columns:
+    Duration:
+      type: numerical
+      expression: 30
+
   order: *common_order
 
 
 medical:
   settings: *expenditure_tables_settings
+
+  columns:
+    Duration:
+      type: numerical
+      expression: 30
+
   order: *common_order
 
 
 transportation:
   settings: *expenditure_tables_settings
+
+  columns:
+    Duration:
+      type: numerical
+      expression: 30
+
   order: *common_order
 
 
 communication:
   settings: *expenditure_tables_settings
+
+  columns:
+    Duration:
+      type: numerical
+      expression: 30
+
   order: *common_order
 
 
 entertainment:
   settings: *expenditure_tables_settings
+
+  columns:
+    Duration:
+      type: numerical
+      expression: 30
+
   order: *common_order
 
 
 education:
   settings: *expenditure_tables_settings
+
+  columns:
+    Duration:
+      type: numerical
+      expression: 30
+
   order: *common_order
 
 
 hotel:
   settings: *expenditure_tables_settings
+
+  columns:
+    Duration:
+      type: numerical
+      expression: 30
+
   order: *common_order
 
 
 other:
   settings: *expenditure_tables_settings
+
+  columns:
+    Duration:
+      type: numerical
+      expression: 30
+
   order: *common_order
 
 
 durable:
   settings: *expenditure_tables_settings
+
+  columns:
+    Duration:
+      type: numerical
+      expression: 360
+
   order: *common_order
 
 
 investment:
   settings: *expenditure_tables_settings
+
+  columns:
+    Duration:
+      type: numerical
+      expression: 360
+
   order: *common_order
 
 
 
 Original_Expenditures:
-  settings:
-    add_duration: true
 
   table_list:
     - food
@@ -277,7 +356,6 @@ other_income:
 _long_other_incomes:
   settings:
     add_table_names: false
-    add_duration: false
 
   table_list:
     - other_income


### PR DESCRIPTION
Adding duration is one of the most time-consuming stages in our process. Currently, the duration is added via classification, using a default value for each table, which leads to numerous issues in the code. Since adding duration is the only operation requiring the table-based default system for classification, we can significantly simplify the classification process and improve the efficiency of adding duration by an order of 10 by including duration in the schema.
